### PR TITLE
Fix unit test core_course\content_item_readonly_repository_test::test…

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -1241,7 +1241,7 @@ if (defined( 'GAME_MOODLE_401')) {
         $type->name = preg_replace('/.*type=/', '', $type->type);
         $type->title = get_string('pluginname', 'game').' - '.get_string('game_'.$kind, 'game');
         $type->link = new moodle_url('/course/modedit.php',
-            array('add' => 'game', 'return' => 0, 'type' => $kind, 'id' => $course->id));
+            array('add' => 'game', 'return' => 0, 'type' => $kind, 'course' => $course->id, 'id' => $course->id,));
         $type->help = '';
         if (empty($type->help) && !empty($type->name) &&
             get_string_manager()->string_exists('help' . $type->name, 'game')) {


### PR DESCRIPTION
…_find_all_for_course

Passing `id` as the test needs it.
And, also passing in `course` as the modedit.php file needs it.

It's a work-around.